### PR TITLE
Start a simple implementation of observer

### DIFF
--- a/Rebulkan.vcxproj
+++ b/Rebulkan.vcxproj
@@ -129,10 +129,11 @@
     </Link>
   </ItemDefinitionGroup>
   <ItemGroup>
-    <ClInclude Include="src\Pattern\ISubject.h" />
-    <ClInclude Include="src\Pattern\IObserver.h" />
     <ClInclude Include="src\GUI\Renderer\Im.h" />
+    <ClInclude Include="src\GUI\VulkanLayer.h" />
     <ClInclude Include="src\Log.h" />
+    <ClInclude Include="src\Pattern\IObserver.h" />
+    <ClInclude Include="src\Pattern\ISubject.h" />
     <ClInclude Include="src\Renderer\Vulkan\VulkanRenderer.h" />
     <ClInclude Include="src\rebulkpch.h" />
     <ClInclude Include="vendor\GLM\glm\common.hpp" />
@@ -548,10 +549,10 @@
     <ClInclude Include="vendor\imgui\backends\imgui_impl_opengl3_loader.h" />
     <ClInclude Include="vendor\imgui\imgui.h" />
     <ClInclude Include="vendor\stb_image\stb_image.h" />
-    <ClInclude Include="src\GUI\VulkanLayer.h" />
   </ItemGroup>
   <ItemGroup>
     <ClCompile Include="src\GUI\Renderer\Im.cpp" />
+    <ClCompile Include="src\GUI\VulkanLayer.cpp" />
     <ClCompile Include="src\Log.cpp" />
     <ClCompile Include="src\Rebulkan.cpp" />
     <ClCompile Include="src\Renderer\Vulkan\VulkanRenderer.cpp" />
@@ -559,11 +560,11 @@
     <ClCompile Include="vendor\imgui\backends\imgui_impl_glfw.cpp" />
     <ClCompile Include="vendor\imgui\backends\imgui_impl_opengl3.cpp" />
     <ClCompile Include="vendor\imgui\imgui.cpp" />
+    <ClCompile Include="vendor\imgui\imgui_demo.cpp" />
     <ClCompile Include="vendor\imgui\imgui_draw.cpp" />
     <ClCompile Include="vendor\imgui\imgui_tables.cpp" />
     <ClCompile Include="vendor\imgui\imgui_widgets.cpp" />
     <ClCompile Include="vendor\stb_image\stb_image.cpp" />
-    <ClCompile Include="src\GUI\VulkanLayer.cpp" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="vendor\GLFW\GLFW.vcxproj">

--- a/Rebulkan.vcxproj
+++ b/Rebulkan.vcxproj
@@ -129,6 +129,8 @@
     </Link>
   </ItemDefinitionGroup>
   <ItemGroup>
+    <ClInclude Include="src\Pattern\ISubject.h" />
+    <ClInclude Include="src\Pattern\IObserver.h" />
     <ClInclude Include="src\GUI\Renderer\Im.h" />
     <ClInclude Include="src\Log.h" />
     <ClInclude Include="src\Renderer\Vulkan\VulkanRenderer.h" />

--- a/Rebulkan.vcxproj.filters
+++ b/Rebulkan.vcxproj.filters
@@ -4,6 +4,15 @@
     <Filter Include="src">
       <UniqueIdentifier>{2DAB880B-99B4-887C-2230-9F7C8E38947C}</UniqueIdentifier>
     </Filter>
+    <Filter Include="src\GUI">
+      <UniqueIdentifier>{C1782FA9-2D58-AE44-3670-391BA2CE14A6}</UniqueIdentifier>
+    </Filter>
+    <Filter Include="src\GUI\Renderer">
+      <UniqueIdentifier>{872599E4-731E-B836-9C50-9DBB88A89742}</UniqueIdentifier>
+    </Filter>
+    <Filter Include="src\Pattern">
+      <UniqueIdentifier>{FA71E505-6627-5EFB-EF1B-58D25BD054FF}</UniqueIdentifier>
+    </Filter>
     <Filter Include="src\Renderer">
       <UniqueIdentifier>{73D1DFBF-5F34-6F64-08BA-A71AF4FB3AE7}</UniqueIdentifier>
     </Filter>
@@ -42,8 +51,20 @@
     </Filter>
   </ItemGroup>
   <ItemGroup>
+    <ClInclude Include="src\GUI\Renderer\Im.h">
+      <Filter>src\GUI\Renderer</Filter>
+    </ClInclude>
+    <ClInclude Include="src\GUI\VulkanLayer.h">
+      <Filter>src\GUI</Filter>
+    </ClInclude>
     <ClInclude Include="src\Log.h">
       <Filter>src</Filter>
+    </ClInclude>
+    <ClInclude Include="src\Pattern\IObserver.h">
+      <Filter>src\Pattern</Filter>
+    </ClInclude>
+    <ClInclude Include="src\Pattern\ISubject.h">
+      <Filter>src\Pattern</Filter>
     </ClInclude>
     <ClInclude Include="src\Renderer\Vulkan\VulkanRenderer.h">
       <Filter>src\Renderer\Vulkan</Filter>
@@ -1290,12 +1311,14 @@
     <ClInclude Include="vendor\stb_image\stb_image.h">
       <Filter>vendor\stb_image</Filter>
     </ClInclude>
-    <ClInclude Include="src\GUI\Renderer\Im.h" />
-    <ClInclude Include="src\GUI\VulkanLayer.h" />
-    <ClInclude Include="src\Pattern\IObserver.h" />
-    <ClInclude Include="src\Pattern\ISubject.h" />
   </ItemGroup>
   <ItemGroup>
+    <ClCompile Include="src\GUI\Renderer\Im.cpp">
+      <Filter>src\GUI\Renderer</Filter>
+    </ClCompile>
+    <ClCompile Include="src\GUI\VulkanLayer.cpp">
+      <Filter>src\GUI</Filter>
+    </ClCompile>
     <ClCompile Include="src\Log.cpp">
       <Filter>src</Filter>
     </ClCompile>
@@ -1317,6 +1340,9 @@
     <ClCompile Include="vendor\imgui\imgui.cpp">
       <Filter>vendor\imgui</Filter>
     </ClCompile>
+    <ClCompile Include="vendor\imgui\imgui_demo.cpp">
+      <Filter>vendor\imgui</Filter>
+    </ClCompile>
     <ClCompile Include="vendor\imgui\imgui_draw.cpp">
       <Filter>vendor\imgui</Filter>
     </ClCompile>
@@ -1329,7 +1355,5 @@
     <ClCompile Include="vendor\stb_image\stb_image.cpp">
       <Filter>vendor\stb_image</Filter>
     </ClCompile>
-    <ClCompile Include="src\GUI\Renderer\Im.cpp" />
-    <ClCompile Include="src\GUI\VulkanLayer.cpp" />
   </ItemGroup>
 </Project>

--- a/Rebulkan.vcxproj.filters
+++ b/Rebulkan.vcxproj.filters
@@ -1292,6 +1292,8 @@
     </ClInclude>
     <ClInclude Include="src\GUI\Renderer\Im.h" />
     <ClInclude Include="src\GUI\VulkanLayer.h" />
+    <ClInclude Include="src\Pattern\IObserver.h" />
+    <ClInclude Include="src\Pattern\ISubject.h" />
   </ItemGroup>
   <ItemGroup>
     <ClCompile Include="src\Log.cpp">

--- a/imgui.ini
+++ b/imgui.ini
@@ -3,19 +3,24 @@ Pos=60,60
 Size=400,400
 Collapsed=0
 
-[Window][Hello, world!]
-Pos=1238,93
-Size=1155,746
+[Window][Dear ImGui Demo]
+Pos=1200,582
+Size=550,594
 Collapsed=0
 
-[Window][Rebulk]
-Pos=1664,381
-Size=756,544
+[Window][Example: Console]
+Pos=923,365
+Size=883,847
 Collapsed=0
 
 [Window][Vulkan Infos]
-Pos=1144,258
-Size=975,967
+Pos=277,229
+Size=1023,797
+Collapsed=0
+
+[Window][Vulkan Infoss]
+Pos=575,231
+Size=32,35
 Collapsed=0
 
 [Docking][Data]

--- a/imgui.ini
+++ b/imgui.ini
@@ -14,8 +14,8 @@ Size=756,544
 Collapsed=0
 
 [Window][Vulkan Infos]
-Pos=583,327
-Size=844,665
+Pos=1144,258
+Size=975,967
 Collapsed=0
 
 [Docking][Data]

--- a/premake5.lua
+++ b/premake5.lua
@@ -41,6 +41,7 @@ project "Rebulkan"
 		"vendor/imgui/imgui_draw.cpp",
 		"vendor/imgui/imgui_tables.cpp",
 		"vendor/imgui/imgui_widgets.cpp",
+		"vendor/imgui/imgui_demo.cpp",
 		"vendor/imgui/backends/imgui_impl_glfw.h",
 		"vendor/imgui/backends/imgui_impl_opengl3.h",
 		"vendor/imgui/backends/imgui_impl_glfw.cpp",

--- a/src/GUI/VulkanLayer.cpp
+++ b/src/GUI/VulkanLayer.cpp
@@ -6,6 +6,7 @@ namespace Rebulk
 	VulkanLayer::VulkanLayer(GLFWwindow* window, VulkanRenderer* vulkanRenderer)
 		: m_Window(window), m_VulkanRenderer(vulkanRenderer)
 	{
+		m_VulkanRenderer->Attach(this);
 	}
 	
 	void VulkanLayer::Create()
@@ -14,30 +15,50 @@ namespace Rebulk
 
 		Rebulk::Im::NewFrame();
 		Rebulk::Im::Begin("Vulkan Infos");
-		Rebulk::Im::Text("Extensions count : %u", m_VulkanRenderer->GetExtensionCount());
+		//Rebulk::Im::Text("Extensions count : %u", m_VulkanRenderer->GetExtensionCount());
 
-		Rebulk::Im::Text("\nExtensions loaded : ");
-		for (const auto& extension : extensions) {
-			Rebulk::Im::Text("\t%s", extension.extensionName);
-		}
+		//Rebulk::Im::Text("\nExtensions loaded : ");
+		//for (const auto& extension : extensions) {
+		//	Rebulk::Im::Text("\t%s", extension.extensionName);
+		//}
 
-		const std::vector<const char*> validationLayers = m_VulkanRenderer->GetValidationLayers();
+		//std::vector<VkLayerProperties> layersAvailable = m_VulkanRenderer->GetLayersAvailable();
 
-		Rebulk::Im::Text("\nValidation layers loaded : ");
-		for (const auto& validation : validationLayers) {
-			Rebulk::Im::Text("\t%s", validation);
-		}
+		//Rebulk::Im::Text("\nAvailable layers");
+		//for (const auto& layer : layersAvailable) {
+		//	Rebulk::Im::Text("\t%s", layer);
+		//}
 
-		Rebulk::Im::End();
+		//const std::vector<const char*> validationLayers = m_VulkanRenderer->GetValidationLayers();
+
+		//Rebulk::Im::Text("\nValidation layers status : %s", m_VulkanRenderer->IsValidationLayersEnabled() ? "enabled" : "disabled");
+
+		//Rebulk::Im::Text("\nValidation layers loaded : ");
+		//for (const auto& validation : validationLayers) {
+		//	Rebulk::Im::Text("\t%s", validation);
+		//}
+
+		//Rebulk::Im::Text("\nVulkan cration instance status : %s", m_VulkanRenderer->IsInstanceCreated() ? "created" : "failed");
 	}
 
 	void VulkanLayer::Render()
 	{
+		Rebulk::Im::End();
 		Rebulk::Im::Render(m_Window);
 	}
 
 	void VulkanLayer::Destroy()
 	{
 		Rebulk::Im::Destroy();
+	}
+
+	void VulkanLayer::Update(std::string& title, std::vector<std::string>& messages)
+	{
+		Rebulk::Im::Text(title);
+		Rebulk::Log::GetLogger()->debug(title);
+		for (const auto& message : messages) {
+			Rebulk::Log::GetLogger()->debug(message);
+			Rebulk::Im::Text("\t%s", message);
+		}
 	}
 }

--- a/src/GUI/VulkanLayer.cpp
+++ b/src/GUI/VulkanLayer.cpp
@@ -15,6 +15,16 @@ namespace Rebulk
 
 		Rebulk::Im::NewFrame();
 		Rebulk::Im::Begin("Vulkan Infos");
+
+		const float footer_height_to_reserve = ImGui::GetStyle().ItemSpacing.y + ImGui::GetFrameHeightWithSpacing();
+		ImGui::BeginChild("ScrollingRegion", ImVec2(0, -footer_height_to_reserve), false, ImGuiWindowFlags_HorizontalScrollbar);
+
+		for (const auto& message : m_Messages) {
+			Rebulk::Log::GetLogger()->debug(message);
+			Rebulk::Im::Text("\t%s", message.c_str());
+			ImGui::Separator();
+		}
+
 		//Rebulk::Im::Text("Extensions count : %u", m_VulkanRenderer->GetExtensionCount());
 
 		//Rebulk::Im::Text("\nExtensions loaded : ");
@@ -39,11 +49,13 @@ namespace Rebulk
 		//}
 
 		//Rebulk::Im::Text("\nVulkan cration instance status : %s", m_VulkanRenderer->IsInstanceCreated() ? "created" : "failed");
+		ImGui::EndChild();
+		Rebulk::Im::End();
+		m_HasBeenUpdated = true;
 	}
 
 	void VulkanLayer::Render()
 	{
-		Rebulk::Im::End();
 		Rebulk::Im::Render(m_Window);
 	}
 
@@ -52,13 +64,10 @@ namespace Rebulk
 		Rebulk::Im::Destroy();
 	}
 
-	void VulkanLayer::Update(std::string& title, std::vector<std::string>& messages)
-	{
-		Rebulk::Im::Text(title);
-		Rebulk::Log::GetLogger()->debug(title);
+	void VulkanLayer::Update(std::vector<std::string>& messages)
+	{		
 		for (const auto& message : messages) {
-			Rebulk::Log::GetLogger()->debug(message);
-			Rebulk::Im::Text("\t%s", message);
+			m_Messages.push_back(message);
 		}
 	}
 }

--- a/src/GUI/VulkanLayer.h
+++ b/src/GUI/VulkanLayer.h
@@ -13,11 +13,12 @@ namespace Rebulk
 		void Create();
 		void Render();
 		void Destroy();
-		void Update(std::string& title, std::vector<std::string>& messages);
+		void Update(std::vector<std::string>& messages);
 
 	private:
 		std::string m_Message;
-
+		bool m_HasBeenUpdated = false;
+		std::vector<std::string>m_Messages = {};
 		GLFWwindow* m_Window = nullptr;
 		VulkanRenderer* m_VulkanRenderer = nullptr;
 	};

--- a/src/GUI/VulkanLayer.h
+++ b/src/GUI/VulkanLayer.h
@@ -2,18 +2,22 @@
 #include "rebulkpch.h"
 #include "Renderer\Vulkan\VulkanRenderer.h"
 #include "GUI\Renderer\Im.h"
+#include "Pattern\IObserver.h"
 
-namespace Rebulk
+namespace Rebulk 
 {
-	class VulkanLayer
+	class VulkanLayer : public IObserver
 	{
 	public:
 		VulkanLayer(GLFWwindow* window, VulkanRenderer* vulkanRenderer);
 		void Create();
 		void Render();
 		void Destroy();
+		void Update(std::string& title, std::vector<std::string>& messages);
 
 	private:
+		std::string m_Message;
+
 		GLFWwindow* m_Window = nullptr;
 		VulkanRenderer* m_VulkanRenderer = nullptr;
 	};

--- a/src/Pattern/IObserver.h
+++ b/src/Pattern/IObserver.h
@@ -10,6 +10,6 @@ namespace Rebulk
 	public:
 		virtual ~IObserver() {};
 		//@todo use json
-		virtual void Update(std::string& title, std::vector<std::string>& messages) = 0;
+		virtual void Update(std::vector<std::string>& messages) = 0;
 	};
 }

--- a/src/Pattern/IObserver.h
+++ b/src/Pattern/IObserver.h
@@ -1,0 +1,15 @@
+#pragma once
+#include <iostream>
+#include <list>
+#include <string>
+
+namespace Rebulk
+{
+	class IObserver
+	{
+	public:
+		virtual ~IObserver() {};
+		//@todo use json
+		virtual void Update(std::string& title, std::vector<std::string>& messages) = 0;
+	};
+}

--- a/src/Pattern/ISubject.h
+++ b/src/Pattern/ISubject.h
@@ -1,0 +1,14 @@
+#pragma once
+#include "Pattern\IObserver.h"
+
+namespace Rebulk
+{
+	class ISubject
+	{
+	public:
+		virtual ~ISubject() {};
+		virtual void Attach(Rebulk::IObserver* observer) = 0;
+		virtual void Detach(Rebulk::IObserver* observer) = 0;
+		virtual void Notify() = 0;
+	};
+}

--- a/src/Rebulkan.cpp
+++ b/src/Rebulkan.cpp
@@ -8,12 +8,6 @@ int main(int argc, char** argv)
 
 	glfwInit();
 
-	uint32_t glfwExtensionCount = 0;
-	const char** glfwExtensions;
-	glfwExtensions = glfwGetRequiredInstanceExtensions(&glfwExtensionCount);
-	
-	Rebulk::VulkanRenderer* renderer = new Rebulk::VulkanRenderer(glfwExtensionCount, glfwExtensions);
-
 	const uint32_t WIDTH = 2560;
 	const uint32_t HEIGHT = 1440;
 
@@ -22,7 +16,9 @@ int main(int argc, char** argv)
 	glfwSwapInterval(1);
 
 	Rebulk::Im::Init(window);
+	Rebulk::VulkanRenderer* renderer = new Rebulk::VulkanRenderer();
 	Rebulk::VulkanLayer* vulkanLayer = new Rebulk::VulkanLayer(window, renderer);
+	renderer->Init();
 
 	while (!glfwWindowShouldClose(window)) {
 		glfwPollEvents();

--- a/src/Rebulkan.cpp
+++ b/src/Rebulkan.cpp
@@ -19,11 +19,13 @@ int main(int argc, char** argv)
 	Rebulk::VulkanRenderer* renderer = new Rebulk::VulkanRenderer();
 	Rebulk::VulkanLayer* vulkanLayer = new Rebulk::VulkanLayer(window, renderer);
 	renderer->Init();
+	//bool show_demo_window = true;
 
 	while (!glfwWindowShouldClose(window)) {
 		glfwPollEvents();
 
 		vulkanLayer->Create();
+		//ImGui::ShowDemoWindow(&show_demo_window);
 		vulkanLayer->Render();
 
 		glfwSwapBuffers(window);

--- a/src/Renderer/Vulkan/VulkanRenderer.h
+++ b/src/Renderer/Vulkan/VulkanRenderer.h
@@ -1,27 +1,50 @@
+#include <algorithm>
 #include "rebulkpch.h"
 #include "vulkan/vulkan.h"
+#include "Pattern\ISubject.h"
 
 namespace Rebulk {
 
-	class VulkanRenderer
+	class VulkanRenderer : public ISubject
 	{
 	public:
-		VulkanRenderer(uint32_t extensionCount, const char* const* extensions);
+		VulkanRenderer();
 		~VulkanRenderer();
+		void Init();
 		inline uint32_t GetExtensionCount() { return m_ExtensionCount; };
 		inline std::vector<VkExtensionProperties> GetExtensions() { return m_Extensions; };
+		inline std::vector<VkLayerProperties> GetLayersAvailable() { return m_LayersAvailable; };
 		inline const std::vector<const char*> GetValidationLayers() { return m_ValidationLayers; };
-
+		inline bool IsValidationLayersEnabled() { return m_EnableValidationLayers; };
+		inline bool IsInstanceCreated() { return m_InstanceCreated; };
+		VKAPI_ATTR VkBool32 VKAPI_CALL DebugCallback(
+			VkDebugUtilsMessageSeverityFlagBitsEXT messageSeverity, VkDebugUtilsMessageTypeFlagsEXT messageType,
+			const VkDebugUtilsMessengerCallbackDataEXT* pCallbackData, void* pUserData
+		);
+		void Attach(IObserver* observer) override;
+		void Detach(IObserver* observer) override;
+		void Notify() override;
 	private:
-		void CreateInstance(uint32_t extensionCount, const char* const* extensions);
+		void CreateInstance();
 		void EnumerateExtensions();
 		bool CheckValidationLayerSupport();
+		void LoadRequiredExtensions();
+		void PopulateDebugMessengerCreateInfo(VkDebugUtilsMessengerCreateInfoEXT& createInfo);
+		void SetupDebugMessenger();
 
 	private:
+		std::list<IObserver*> m_Observers;
+		std::string m_Title;
+		std::vector<std::string> m_Messages;
 		const std::vector<const char*> m_ValidationLayers = { "VK_LAYER_KHRONOS_validation" };
 		const std::vector<const char*> m_DeviceExtensions = { VK_KHR_SWAPCHAIN_EXTENSION_NAME };
 		VkInstance m_Instance = VK_NULL_HANDLE;
 		uint32_t m_ExtensionCount = 0;
-		std::vector<VkExtensionProperties> m_Extensions;
+		std::vector<VkExtensionProperties> m_Extensions = {};
+		std::vector<VkLayerProperties> m_LayersAvailable = {};
+		bool m_EnableValidationLayers = false;
+		bool m_InstanceCreated = false;
+		std::vector<const char*> m_RequiredExtensions = {};
+		VkDebugUtilsMessengerEXT callback = VK_NULL_HANDLE;
 	};
 }

--- a/src/Renderer/Vulkan/VulkanRenderer.h
+++ b/src/Renderer/Vulkan/VulkanRenderer.h
@@ -34,7 +34,6 @@ namespace Rebulk {
 
 	private:
 		std::list<IObserver*> m_Observers;
-		std::string m_Title;
 		std::vector<std::string> m_Messages;
 		const std::vector<const char*> m_ValidationLayers = { "VK_LAYER_KHRONOS_validation" };
 		const std::vector<const char*> m_DeviceExtensions = { VK_KHR_SWAPCHAIN_EXTENSION_NAME };


### PR DESCRIPTION
Start a simple implementation of observer for VulkanLayer to access to the log message of Vulkan API. 
Working but :

TODO : Inject an interface to VulkanLayer() rather than impl VulkanRenderer*.
TODO : Move ImGui::BeginChild, ImGui::GetStyle(), ImGui::Separator() and ImGui::EndChild() to Rebulk::Im::xxx()