### PR TITLE
Optimizations for descriptors sets usage

### DIFF
--- a/shaders/shader.frag
+++ b/shaders/shader.frag
@@ -1,5 +1,6 @@
 #version 450
 #extension GL_ARB_separate_shader_objects : enable
+#extension GL_EXT_nonuniform_qualifier : enable
 
 layout(location = 0) out vec4 outputColor;
 
@@ -7,7 +8,7 @@ layout(location = 0) in vec4 fragColor;
 layout(location = 1) in vec2 fragTexCoord;
 layout(location = 2) flat in int index;
 
-layout(binding = 1) uniform sampler2D texSampler[100];
+layout(binding = 1) uniform sampler2D texSampler[];
 
 layout(push_constant) uniform PER_OBJECT
 {

--- a/shaders/shader.frag
+++ b/shaders/shader.frag
@@ -3,18 +3,10 @@
 #extension GL_EXT_nonuniform_qualifier : enable
 
 layout(location = 0) out vec4 outputColor;
+layout(location = 0) in vec2 fragTexCoord;
 
-layout(location = 0) in vec4 fragColor;
-layout(location = 1) in vec2 fragTexCoord;
-layout(location = 2) flat in int index;
-
-layout(binding = 1) uniform sampler2D texSampler[];
-
-layout(push_constant) uniform PER_OBJECT
-{
-	int imgIdx;
-}pc;
+layout(binding = 1) uniform sampler2D texSampler;
 
 void main() {    
-    outputColor = texture(texSampler[index], fragTexCoord);    
+    outputColor = texture(texSampler, fragTexCoord);    
 }

--- a/shaders/shader.vert
+++ b/shaders/shader.vert
@@ -2,29 +2,25 @@
 #extension GL_ARB_separate_shader_objects : enable
 #extension GL_EXT_nonuniform_qualifier : enable
 
-layout(binding = 0) uniform UniformBufferObject {
+struct UBO 
+{
     mat4 model;
     mat4 view;
     mat4 proj;
-} ubo[];
+};
 
-layout(push_constant) uniform PER_OBJECT
-{
-	int imgIdx;
-}pc;
+layout(set = 0, binding = 0) uniform UniformBufferObject {
+   UBO ubos[10000];
+};
 
 layout(location = 0) in vec3 pos;
 layout(location = 1) in vec3 color;
 layout(location = 2) in vec2 texCoord;
 
-layout(location = 0) out vec4 fragColor;
-layout(location = 1) out vec2 fragTexCoord;
-layout(location = 2) out int index;
+layout(location = 0) out vec2 fragTexCoord;
 
 
 void main() {
-    gl_Position = ubo[pc.imgIdx].proj * ubo[pc.imgIdx].view * ubo[pc.imgIdx].model * vec4(pos, 1.0);
-    fragColor = vec4(color, 1.0);
+    gl_Position = ubos[gl_InstanceIndex].proj * ubos[gl_InstanceIndex].view * ubos[gl_InstanceIndex].model * vec4(pos, 1.0);
     fragTexCoord = texCoord;
-    index = pc.imgIdx;
 }

--- a/shaders/shader.vert
+++ b/shaders/shader.vert
@@ -1,11 +1,12 @@
 #version 450
 #extension GL_ARB_separate_shader_objects : enable
+#extension GL_EXT_nonuniform_qualifier : enable
 
 layout(binding = 0) uniform UniformBufferObject {
     mat4 model;
     mat4 view;
     mat4 proj;
-} ubo[3];
+} ubo[];
 
 layout(push_constant) uniform PER_OBJECT
 {

--- a/src/Rebulk/Component/Camera.cpp
+++ b/src/Rebulk/Component/Camera.cpp
@@ -51,7 +51,7 @@ namespace Rbk
 
 	void Camera::UpdateSpeed(float timeStep)
 	{
-		m_Speed = 1.5f * timeStep;
+		m_Speed = 10.0f * timeStep;
 	}
 
 	void Camera::UpdateYP(float xoffset, float yoffset)

--- a/src/Rebulk/GUI/Layer/VulkanLayer.cpp
+++ b/src/Rebulk/GUI/Layer/VulkanLayer.cpp
@@ -43,9 +43,18 @@ namespace Rbk
 		ImGui::Separator();
 		Rbk::Im::Text("Current frame %d", m_Adapter->Rdr()->GetCurrentFrame());
 		ImGui::Separator();
-		Rbk::Im::Text("Mesh count %d", m_Adapter->GetMesh().count);
-		Rbk::Im::Text("Vertex count %d", m_Adapter->GetMesh().mesh.vertices.size());
-		Rbk::Im::Text("Index count %d", m_Adapter->GetMesh().mesh.indices.size());
+		Rbk::Im::Text("Total mesh loaded %d", m_Adapter->GetMesh().count);
+		Rbk::Im::Text("Total mesh instanced %d", m_Adapter->GetMesh().totalInstances);
+		Rbk::Im::Text("Total vertex count %d", m_Adapter->GetMesh().mesh.vertices.size());
+		Rbk::Im::Text("Total index count %d", m_Adapter->GetMesh().mesh.indices.size());
+		Rbk::Im::Text("Max UBO buffer size by chunk %d", m_Adapter->GetMesh().maxUniformBufferRange);
+		Rbk::Im::Text("UBO buffer size by chunk %d", m_Adapter->GetMesh().uniformBufferChunkSize);
+		Rbk::Im::Text("Total UBO buffer %d", m_Adapter->GetMesh().uniformBuffersCount);
+
+		Rbk::Im::Text("Stats per mesh :");
+		for (auto item : m_Adapter->GetMesh().mesh.meshNames) {
+			Rbk::Im::Text("\tMesh named %s with %d instances", item.first, item.second);
+		}
 		ImGui::Separator();
 		Rbk::Im::Text("Shader count %d", m_Adapter->GetShaders().shaders.size());
 		ImGui::Separator();

--- a/src/Rebulk/Manager/RenderManager.cpp
+++ b/src/Rebulk/Manager/RenderManager.cpp
@@ -60,8 +60,8 @@ namespace Rbk
 		Mesh mesh = Rbk::TinyObjLoader::LoadMesh(path, shouldInverseTextureY);
 
 		//@todo Add MeshManager
-		for (int x = 0; x < 10; x++) {
-			for (int y = 0; y < 10; y++) {
+		for (int x = 0; x < 20; x++) {
+			for (int y = 0; y < 20; y++) {
 				pos = glm::vec3(0.3f * x, -0.5f, -0.3f * y);
 
 				m_Renderer->AddMesh(mesh, textureName, pos);

--- a/src/Rebulk/Manager/RenderManager.cpp
+++ b/src/Rebulk/Manager/RenderManager.cpp
@@ -60,8 +60,8 @@ namespace Rbk
 		Mesh mesh = Rbk::TinyObjLoader::LoadMesh(path, shouldInverseTextureY);
 
 		//@todo Add MeshManager
-		for (int x = 0; x < 20; x++) {
-			for (int y = 0; y < 20; y++) {
+		for (int x = 0; x < 100; x++) {
+			for (int y = 0; y < 100; y++) {
 				pos = glm::vec3(0.3f * x, -0.5f, -0.3f * y);
 
 				m_Renderer->AddMesh(name, mesh, textureName, pos);

--- a/src/Rebulk/Manager/RenderManager.cpp
+++ b/src/Rebulk/Manager/RenderManager.cpp
@@ -40,9 +40,9 @@ namespace Rbk
 		glm::vec3 pos2 = glm::vec3(-0.5f, -0.5f, -0.5f);
 		glm::vec3 pos3 = glm::vec3(0.1f, -0.8f, 0.0f);
 
-		AddTexture("viking_room", "mesh/viking/viking_room.png");
-		AddTexture("diffuse_backpack", "mesh/backpack/diffuse.png");
-		AddTexture("diffuse_moon", "mesh/moon/diffuse.jpg");
+		//AddTexture("viking_room", "mesh/viking/viking_room.png");
+		//AddTexture("diffuse_backpack", "mesh/backpack/diffuse.png");
+		//AddTexture("diffuse_moon", "mesh/moon/diffuse.jpg");
 		AddTexture("minecraft_grass", "mesh/minecraft/Grass_Block_TEX.png");
 
 		//AddMesh("mesh/backpack/backpack.obj", "diffuse_backpack", pos2, false);

--- a/src/Rebulk/Manager/RenderManager.cpp
+++ b/src/Rebulk/Manager/RenderManager.cpp
@@ -47,7 +47,7 @@ namespace Rbk
 
 		//AddMesh("mesh/backpack/backpack.obj", "diffuse_backpack", pos2, false);
 		//AddMesh("mesh/viking/viking_room.obj", "viking_room", pos1);
-		AddMesh("mesh/minecraft/Grass_Block.obj", "minecraft_grass", pos3);
+		AddMesh("cube", "mesh/minecraft/Grass_Block.obj", "minecraft_grass", pos3);
 	}
 
 	void RenderManager::AddCamera(Camera* camera)
@@ -55,7 +55,7 @@ namespace Rbk
 		m_Renderer->AddCamera(camera);
 	}
 
-	void RenderManager::AddMesh(const char* path, const char* textureName, glm::vec3 pos, bool shouldInverseTextureY)
+	void RenderManager::AddMesh(const char* name, const char* path, const char* textureName, glm::vec3 pos, bool shouldInverseTextureY)
 	{
 		Mesh mesh = Rbk::TinyObjLoader::LoadMesh(path, shouldInverseTextureY);
 
@@ -64,7 +64,7 @@ namespace Rbk
 			for (int y = 0; y < 20; y++) {
 				pos = glm::vec3(0.3f * x, -0.5f, -0.3f * y);
 
-				m_Renderer->AddMesh(mesh, textureName, pos);
+				m_Renderer->AddMesh(name, mesh, textureName, pos);
 			}
 		}
 	}

--- a/src/Rebulk/Manager/RenderManager.h
+++ b/src/Rebulk/Manager/RenderManager.h
@@ -16,7 +16,7 @@ namespace Rbk
 		void Init();
 		void AddCamera(Camera* camera);
 		void AddTexture(const char* name, const char* path);
-		void AddMesh(const char* path, const char* textureName, glm::vec3 pos, bool shouldInverseTextureY = true);
+		void AddMesh(const char* name, const char* path, const char* textureName, glm::vec3 pos, bool shouldInverseTextureY = true);
 		void AddShader(std::string name, std::vector<char> vertShaderCode, std::vector<char> fragShaderCode);
 		void PrepareDraw();
 		void Draw();

--- a/src/Rebulk/Renderer/Adapter/IRendererAdapter.h
+++ b/src/Rebulk/Renderer/Adapter/IRendererAdapter.h
@@ -12,7 +12,7 @@ namespace Rbk
 		virtual void AddShader(std::string name, std::vector<char> vertexShaderCode, std::vector<char> fragShaderCode) = 0;
 		virtual void AddCamera(Camera* camera) = 0;
 		virtual void AddTexture(const char* name, const char* path) = 0;
-		virtual void AddMesh(Rbk::Mesh mesh, const char* textureName, glm::vec3 pos) = 0;
+		virtual void AddMesh(const char* name, Rbk::Mesh mesh, const char* textureName, glm::vec3 pos) = 0;
 		virtual void PrepareDraw() = 0;
 		virtual void Draw() = 0;
 		virtual void Destroy() = 0;

--- a/src/Rebulk/Renderer/Adapter/VulkanAdapter.cpp
+++ b/src/Rebulk/Renderer/Adapter/VulkanAdapter.cpp
@@ -212,17 +212,22 @@ namespace Rbk
 			m_Pipelines.emplace_back(vPipelineWireFramed);
 		}
 
+
+
 		m_IsPrepared = true;
 	}
 
 	void VulkanAdapter::UpdatePositions()
 	{
-		for (auto& ubo : m_Meshes.mesh.ubos) {
-			ubo.view = m_Camera->LookAt();
+		for (int i = 0; i < m_Meshes.count; i++) {
+
+			m_Meshes.mesh.ubos[i].view = m_Camera->LookAt();
 			
 			if (m_MakeSpin) {		
-				ubo.model = glm::rotate(ubo.model, (float)glfwGetTime() * glm::radians(50.0f), glm::vec3(0.0f, 1.0f, 0.0f));
+				m_Meshes.mesh.ubos[i].model = glm::rotate(m_Meshes.mesh.ubos[i].model, (float)glfwGetTime() * glm::radians(50.0f), glm::vec3(0.0f, 1.0f, 0.0f));
 			}
+
+			m_Renderer->UpdateUniformBuffer(m_Meshes.uniformBuffers[i], m_Meshes.mesh.ubos[i]);
 		}
 	}
 
@@ -234,6 +239,7 @@ namespace Rbk
 
 		SouldResizeSwapChain();
 		UpdatePositions();
+		VulkanPipeline ppline = (!m_WireFrameModeOn) ? m_Pipelines[0] : m_Pipelines[1];
 
 		for (size_t i = 0; i < m_SwapChainImages.size(); i++) {
 						
@@ -250,9 +256,6 @@ namespace Rbk
 			m_Renderer->BeginRenderPass(m_RenderPass, m_CommandBuffers[m_ImageIndex], m_SwapChainFramebuffers[m_ImageIndex]);
 			m_Renderer->SetViewPort(m_CommandBuffers[m_ImageIndex]);
 			m_Renderer->SetScissor(m_CommandBuffers[m_ImageIndex]);
-
-			VulkanPipeline ppline = (!m_WireFrameModeOn) ? m_Pipelines[0] : m_Pipelines[1];
-
 			m_Renderer->BindPipeline(m_CommandBuffers[m_ImageIndex], ppline.graphicsPipeline[0]);
 			m_Renderer->UpdateDescriptorSets(m_Meshes, m_Textures, ppline);
 			m_Renderer->Draw(m_CommandBuffers[m_ImageIndex], m_Meshes, ppline);

--- a/src/Rebulk/Renderer/Adapter/VulkanAdapter.cpp
+++ b/src/Rebulk/Renderer/Adapter/VulkanAdapter.cpp
@@ -202,11 +202,11 @@ namespace Rbk
 		if (0 == m_Pipelines.size()) {
 			VulkanPipeline vPipeline;
 			vPipeline.pipelineCache = 0;
-			vPipeline.descriptorPool = m_Renderer->CreateDescriptorPool(m_SwapChainImages.size());			
+			vPipeline.descriptorPool = m_Renderer->CreateDescriptorPool(m_Meshes.uniformBuffersCount);
 
-			for (int i = 0; i < m_SwapChainImages.size(); i++) {
-				vPipeline.descriptorSetLayouts.emplace_back(m_Renderer->CreateDescriptorSetLayout());
-				vPipeline.descriptorSets.emplace_back(m_Renderer->CreateDescriptorSets(vPipeline.descriptorPool, m_SwapChainImages, vPipeline.descriptorSetLayouts));
+			vPipeline.descriptorSetLayouts.emplace_back(m_Renderer->CreateDescriptorSetLayout());
+			for (int i = 0; i < m_Meshes.uniformBuffersCount; i++) {
+				vPipeline.descriptorSets.emplace_back(m_Renderer->CreateDescriptorSets(vPipeline.descriptorPool, vPipeline.descriptorSetLayouts));
 			}
 
 			vPipeline.pipelineLayout = m_Renderer->CreatePipelineLayout(vPipeline.descriptorSets, vPipeline.descriptorSetLayouts);			
@@ -215,11 +215,11 @@ namespace Rbk
 
 			VulkanPipeline vPipelineWireFramed;
 			vPipelineWireFramed.pipelineCache = 0;
-			vPipelineWireFramed.descriptorPool = m_Renderer->CreateDescriptorPool(m_SwapChainImages.size());
+			vPipelineWireFramed.descriptorPool = m_Renderer->CreateDescriptorPool(m_Meshes.uniformBuffersCount);
 
-			for (int i = 0; i < m_SwapChainImages.size(); i++) {
-				vPipelineWireFramed.descriptorSetLayouts.emplace_back(m_Renderer->CreateDescriptorSetLayout());
-				vPipelineWireFramed.descriptorSets.emplace_back(m_Renderer->CreateDescriptorSets(vPipelineWireFramed.descriptorPool, m_SwapChainImages, vPipelineWireFramed.descriptorSetLayouts));
+			vPipelineWireFramed.descriptorSetLayouts.emplace_back(m_Renderer->CreateDescriptorSetLayout());
+			for (int i = 0; i < m_Meshes.uniformBuffersCount; i++) {
+				vPipelineWireFramed.descriptorSets.emplace_back(m_Renderer->CreateDescriptorSets(vPipelineWireFramed.descriptorPool, vPipelineWireFramed.descriptorSetLayouts));
 			}
 
 			vPipelineWireFramed.pipelineLayout = m_Renderer->CreatePipelineLayout(vPipelineWireFramed.descriptorSets, vPipelineWireFramed.descriptorSetLayouts);

--- a/src/Rebulk/Renderer/Adapter/VulkanAdapter.cpp
+++ b/src/Rebulk/Renderer/Adapter/VulkanAdapter.cpp
@@ -163,7 +163,7 @@ namespace Rbk
 			std::pair<VkBuffer, VkDeviceMemory> uniformBuffer = m_Renderer->CreateUniformBuffers(1);
 			m_Meshes.uniformBuffers.emplace_back(uniformBuffer);
 		}
-
+		
 		m_SwapChainImageViews.resize(m_SwapChainImages.size());
 
 		for (uint32_t i = 0; i < m_SwapChainImages.size(); i++) {
@@ -196,7 +196,7 @@ namespace Rbk
 			vPipeline.pipelineCache = 0;
 			vPipeline.descriptorPool = m_Renderer->CreateDescriptorPool(m_SwapChainImages);			
 			vPipeline.descriptorSetLayouts.emplace_back(m_Renderer->CreateDescriptorSetLayout(m_Meshes.count));
-			vPipeline.descriptorSets.emplace_back(m_Renderer->CreateDescriptorSets(vPipeline.descriptorPool, m_SwapChainImages, vPipeline.descriptorSetLayouts));		
+			vPipeline.descriptorSets.emplace_back(m_Renderer->CreateDescriptorSets(vPipeline.descriptorPool, m_SwapChainImages, vPipeline.descriptorSetLayouts));	
 			vPipeline.pipelineLayout = m_Renderer->CreatePipelineLayout(vPipeline.descriptorSets, vPipeline.descriptorSetLayouts);			
 			vPipeline.graphicsPipeline.emplace_back(m_Renderer->CreateGraphicsPipeline(m_RenderPass, vPipeline, m_Shaders));
 			m_Pipelines.emplace_back(vPipeline);
@@ -254,7 +254,8 @@ namespace Rbk
 			VulkanPipeline ppline = (!m_WireFrameModeOn) ? m_Pipelines[0] : m_Pipelines[1];
 
 			m_Renderer->BindPipeline(m_CommandBuffers[m_ImageIndex], ppline.graphicsPipeline[0]);
-			m_Renderer->Draw(m_CommandBuffers[m_ImageIndex], m_Meshes, m_Textures, ppline);
+			m_Renderer->UpdateDescriptorSets(m_Meshes, m_Textures, ppline);
+			m_Renderer->Draw(m_CommandBuffers[m_ImageIndex], m_Meshes, ppline);
 			m_Renderer->EndRenderPass(m_CommandBuffers[m_ImageIndex]);
 			m_Renderer->EndCommandBuffer(m_CommandBuffers[m_ImageIndex]);
 

--- a/src/Rebulk/Renderer/Adapter/VulkanAdapter.cpp
+++ b/src/Rebulk/Renderer/Adapter/VulkanAdapter.cpp
@@ -226,7 +226,12 @@ namespace Rbk
 			vPipelineWireFramed.graphicsPipeline.emplace_back(m_Renderer->CreateGraphicsPipeline(m_RenderPass, vPipelineWireFramed, m_Shaders, true));
 
 			m_Pipelines.emplace_back(vPipelineWireFramed);
+
+			for (int i = 0; i < m_Meshes.uniformBuffersCount; i++) {
+				m_Renderer->UpdateDescriptorSets(m_Meshes, m_Meshes.uniformBuffers[i], m_Textures, vPipeline.descriptorSets[i]);
+			}
 		}
+
 
 		m_IsPrepared = true;
 	}
@@ -276,6 +281,9 @@ namespace Rbk
 		UpdatePositions();
 		VulkanPipeline ppline = (!m_WireFrameModeOn) ? m_Pipelines[0] : m_Pipelines[1];
 
+		VkBuffer vertexBuffers[] = { m_Meshes.meshVBuffer.first };
+		VkDeviceSize offsets[] = { 0 };
+
 		for (size_t i = 0; i < m_SwapChainImages.size(); i++) {
 						
 			m_ImageIndex = m_Renderer->AcquireNextImageKHR(m_SwapChain, m_Semaphores);
@@ -292,11 +300,7 @@ namespace Rbk
 			m_Renderer->SetViewPort(m_CommandBuffers[m_ImageIndex]);
 			m_Renderer->SetScissor(m_CommandBuffers[m_ImageIndex]);
 			m_Renderer->BindPipeline(m_CommandBuffers[m_ImageIndex], ppline.graphicsPipeline[0]);
-
-			//for (auto chunk : m_Meshes.uniformBuffers) {
-				m_Renderer->Draw(m_CommandBuffers[m_ImageIndex], m_Meshes, m_Textures, ppline);
-			//}			
-
+			m_Renderer->Draw(m_CommandBuffers[m_ImageIndex], m_Meshes, m_Textures, ppline);
 			m_Renderer->EndRenderPass(m_CommandBuffers[m_ImageIndex]);
 			m_Renderer->EndCommandBuffer(m_CommandBuffers[m_ImageIndex]);
 
@@ -305,9 +309,9 @@ namespace Rbk
 				m_Renderer->QueuePresent(m_ImageIndex, m_SwapChain, m_Semaphores);
 			}
 
-			m_Renderer->WaitIdle();
+			//m_Renderer->WaitIdle();
 		}
-		m_Renderer->ResetCommandPool(m_CommandPool);
+		//m_Renderer->ResetCommandPool(m_CommandPool);
 	}
 
 	void VulkanAdapter::Destroy()

--- a/src/Rebulk/Renderer/Adapter/VulkanAdapter.h
+++ b/src/Rebulk/Renderer/Adapter/VulkanAdapter.h
@@ -24,7 +24,7 @@ namespace Rbk
 		virtual void Init() override;
 		virtual void AddCamera(Camera* camera) override;
 		virtual void AddShader(std::string name, std::vector<char> vertexShaderCode, std::vector<char> fragShaderCode) override;
-		virtual void AddMesh(Rbk::Mesh mesh, const char* textureName, glm::vec3 pos) override;
+		virtual void AddMesh(const char* name, Rbk::Mesh mesh, const char* textureName, glm::vec3 pos) override;
 		virtual void AddTexture(const char* name, const char* path) override;
 		virtual void PrepareDraw() override;
 		virtual void Draw() override;

--- a/src/Rebulk/Renderer/Mesh.h
+++ b/src/Rebulk/Renderer/Mesh.h
@@ -57,6 +57,7 @@ namespace Rbk
 		std::vector<uint32_t> indices;
 		std::vector<UniformBufferObject> ubos;
 		std::map<int32_t, const char*> textureNames;
+		std::map<const char*, int32_t> meshNames;
 	};
 }
 

--- a/src/Rebulk/Renderer/Vulkan/VulkanRenderer.cpp
+++ b/src/Rebulk/Renderer/Vulkan/VulkanRenderer.cpp
@@ -588,7 +588,7 @@ namespace Rbk {
 		layoutInfo.bindingCount = static_cast<uint32_t>(bindings.size());
 		layoutInfo.pBindings = bindings.data();
 		layoutInfo.flags = VK_DESCRIPTOR_SET_LAYOUT_CREATE_UPDATE_AFTER_BIND_POOL_BIT;
-
+		
 		if (vkCreateDescriptorSetLayout(m_Device, &layoutInfo, nullptr, &descriptorSetLayout) != VK_SUCCESS)
 		{
 			throw std::runtime_error("failed to create descriptor set layout!");
@@ -1063,7 +1063,7 @@ namespace Rbk {
 		VkDescriptorSetAllocateInfo allocInfo{};
 		allocInfo.sType = VK_STRUCTURE_TYPE_DESCRIPTOR_SET_ALLOCATE_INFO;
 		allocInfo.descriptorPool = descriptorPool;
-		allocInfo.descriptorSetCount = 1;
+		allocInfo.descriptorSetCount = descriptorSetLayouts.size();
 		allocInfo.pSetLayouts = descriptorSetLayouts.data();
 
 		VkResult result = vkAllocateDescriptorSets(m_Device, &allocInfo, &descriptorSet);
@@ -1094,7 +1094,6 @@ namespace Rbk {
 			imageInfo.sampler = vTextures[vMesh.mesh.textureNames[i]].sampler;
 			imageInfos.emplace_back(imageInfo);
 
-			UpdateUniformBuffer(vMesh.uniformBuffers[i], vMesh.mesh.ubos[i]);
 		}
 
 		descriptorWrites[0].sType = VK_STRUCTURE_TYPE_WRITE_DESCRIPTOR_SET;

--- a/src/Rebulk/Renderer/Vulkan/VulkanRenderer.cpp
+++ b/src/Rebulk/Renderer/Vulkan/VulkanRenderer.cpp
@@ -1056,7 +1056,7 @@ namespace Rbk {
 		return descriptorPool;
 	}
 
-	VkDescriptorSet VulkanRenderer::CreateDescriptorSets(VkDescriptorPool descriptorPool, std::vector<VkImage> swapChainImages, std::vector<VkDescriptorSetLayout> descriptorSetLayouts)
+	VkDescriptorSet VulkanRenderer::CreateDescriptorSets(VkDescriptorPool descriptorPool, std::vector<VkDescriptorSetLayout> descriptorSetLayouts)
 	{
 		VkDescriptorSet descriptorSet;
 
@@ -1257,6 +1257,8 @@ namespace Rbk {
 	{	
 		VkBuffer vertexBuffers[] = { vMesh.meshVBuffer.first };
 		VkDeviceSize offsets[] = { 0 };
+
+		int j = 0;
 
 		for (int i = 0; i < vMesh.uniformBuffersCount; i++) {
 

--- a/src/Rebulk/Renderer/Vulkan/VulkanRenderer.cpp
+++ b/src/Rebulk/Renderer/Vulkan/VulkanRenderer.cpp
@@ -1258,11 +1258,7 @@ namespace Rbk {
 		VkBuffer vertexBuffers[] = { vMesh.meshVBuffer.first };
 		VkDeviceSize offsets[] = { 0 };
 
-		int j = 0;
-
 		for (int i = 0; i < vMesh.uniformBuffersCount; i++) {
-
-			UpdateDescriptorSets(vMesh, vMesh.uniformBuffers[i], vTextures, pipeline.descriptorSets[i]);
 
 			vkCmdBindVertexBuffers(commandBuffer, 0, 1, vertexBuffers, offsets);
 			vkCmdBindIndexBuffer(commandBuffer, vMesh.meshIBuffer.first, 0, VK_INDEX_TYPE_UINT32);

--- a/src/Rebulk/Renderer/Vulkan/VulkanRenderer.cpp
+++ b/src/Rebulk/Renderer/Vulkan/VulkanRenderer.cpp
@@ -1083,15 +1083,10 @@ namespace Rbk {
 
 		int32_t offset = 0;
 
-		for (int i = 0; i < vMesh.uniformBuffers.size(); i++) {
-
-			if (i > 0) {
-				offset = sizeof(UniformBufferObject) * i;
-			}
-
+		for (int i = 0; i < vMesh.uniformBuffersCount; i++) {
 			VkDescriptorBufferInfo bufferInfo{};
 			bufferInfo.buffer = vMesh.uniformBuffers[i].first;
-			bufferInfo.offset = offset;
+			bufferInfo.offset = 0;
 			bufferInfo.range = VK_WHOLE_SIZE;
 			bufferInfos.emplace_back(bufferInfo);
 		}

--- a/src/Rebulk/Renderer/Vulkan/VulkanRenderer.cpp
+++ b/src/Rebulk/Renderer/Vulkan/VulkanRenderer.cpp
@@ -1281,17 +1281,7 @@ namespace Rbk {
 			nullptr
 		);
 
-		uint32_t verticesOffsetIndex = 0;
-		uint32_t indicesOffsetIndex = 0;
-
-		//for (int i = 0; i < vMesh.count; i++) {
-		int i = 0;
-		//vkCmdPushConstants(commandBuffer, pipeline.pipelineLayout, VK_SHADER_STAGE_VERTEX_BIT, 0, sizeof(push.data()), push.data());
-
-			//verticesOffsetIndex = (i == 0) ? 0 : vMesh.vertexOffset[i - 1];
-			//indicesOffsetIndex = (i == 0) ? 0 : vMesh.indicesOffset[i - 1];
-		vkCmdDrawIndexed(commandBuffer, vMesh.vertexIndicesCount, vMesh.count, 0, 0, 0);
-		//
+		vkCmdDrawIndexed(commandBuffer, vMesh.vertexIndicesCount, vMesh.totalInstances, 0, 0, 0);
 	}
 
 	void VulkanRenderer::AddPipelineBarrier(VkCommandBuffer commandBuffer, VkImageMemoryBarrier renderBarrier, VkPipelineStageFlags srcStageMask, VkPipelineStageFlags dstStageMask, VkDependencyFlags dependencyFlags)

--- a/src/Rebulk/Renderer/Vulkan/VulkanRenderer.h
+++ b/src/Rebulk/Renderer/Vulkan/VulkanRenderer.h
@@ -78,10 +78,10 @@ namespace Rbk {
 		**/
 		VkRenderPass CreateRenderPass(VkSampleCountFlagBits msaaSamples);
 		VkShaderModule CreateShaderModule(const std::vector<char>& code);
-		VkDescriptorPool CreateDescriptorPool(std::vector<VkImage> swapChainImages);
-		VkDescriptorSetLayout CreateDescriptorSetLayout(uint32_t meshCount);
+		VkDescriptorPool CreateDescriptorPool(uint32_t size);
+		VkDescriptorSetLayout CreateDescriptorSetLayout();
 		VkDescriptorSet CreateDescriptorSets(VkDescriptorPool descriptorPool, std::vector<VkImage> swapChainImages, std::vector<VkDescriptorSetLayout> descriptorSetLayouts);
-		void UpdateDescriptorSets(VulkanMesh vMesh, std::map<const char*, VulkanTexture> vTextures, VulkanPipeline pipeline);
+		void UpdateDescriptorSets(VulkanMesh vMesh, std::pair<VkBuffer, VkDeviceMemory> uniformBuffer, std::map<const char*, VulkanTexture> vTextures, VkDescriptorSet descriptorSet);
 		VkPipelineLayout CreatePipelineLayout(std::vector<VkDescriptorSet> descriptorSets, std::vector<VkDescriptorSetLayout> descriptorSetLayouts);
 		VkPipeline CreateGraphicsPipeline(VkRenderPass renderPass, VulkanPipeline pipeline, VulkanShaders shaders, bool wireFrameModeOn = false);
 		VkSwapchainKHR CreateSwapChain(std::vector<VkImage>& swapChainImages, VkSwapchainKHR oldSwapChain = VK_NULL_HANDLE);
@@ -118,7 +118,7 @@ namespace Rbk {
 		void SetViewPort(VkCommandBuffer commandBuffer);
 		void SetScissor(VkCommandBuffer commandBuffer);
 		void BindPipeline(VkCommandBuffer commandBuffer, VkPipeline pipeline);
-		void Draw(VkCommandBuffer commandBuffer, VulkanMesh vMesh, VulkanPipeline pipeline);
+		void Draw(VkCommandBuffer commandBuffer, VulkanMesh vMesh, std::map<const char*, VulkanTexture> vTextures, VulkanPipeline pipeline);
 		uint32_t AcquireNextImageKHR(VkSwapchainKHR swapChain, std::pair<std::vector<VkSemaphore>, std::vector<VkSemaphore>>& semaphores);
 		void QueueSubmit(VkCommandBuffer commandBuffer);
 		void QueueSubmit(uint32_t imageIndex, VkCommandBuffer commandBuffer, std::pair<std::vector<VkSemaphore>, std::vector<VkSemaphore>>& semaphores);

--- a/src/Rebulk/Renderer/Vulkan/VulkanRenderer.h
+++ b/src/Rebulk/Renderer/Vulkan/VulkanRenderer.h
@@ -194,7 +194,7 @@ namespace Rbk {
 		GLFWwindow* m_Window = VK_NULL_HANDLE;
 
 		const std::vector<const char*> m_ValidationLayers = { "VK_LAYER_KHRONOS_validation" };
-		const std::vector<const char*> m_DeviceExtensions = { VK_KHR_SWAPCHAIN_EXTENSION_NAME };
+		const std::vector<const char*> m_DeviceExtensions = { VK_KHR_SWAPCHAIN_EXTENSION_NAME, VK_KHR_PUSH_DESCRIPTOR_EXTENSION_NAME };
 
 		bool m_InstanceCreated = false;
 		bool m_EnableValidationLayers = false;

--- a/src/Rebulk/Renderer/Vulkan/VulkanRenderer.h
+++ b/src/Rebulk/Renderer/Vulkan/VulkanRenderer.h
@@ -30,13 +30,15 @@ namespace Rbk {
 	struct VulkanMesh
 	{
 		Rbk::Mesh mesh;
-		std::vector<uint32_t>indexCount = {};
+		uint32_t vertexIndicesCount = 0;
 		std::vector<uint32_t>vertexOffset = {};
 		std::vector<uint32_t>indicesOffset = {};
 		std::pair<VkBuffer, VkDeviceMemory> meshVBuffer = { nullptr, nullptr };
 		std::pair<VkBuffer, VkDeviceMemory> meshIBuffer = { nullptr, nullptr };
 		std::vector<std::pair<VkBuffer, VkDeviceMemory>>uniformBuffers;
 		int32_t count = 0;
+		int32_t uniformBuffersCount = 0;
+		int32_t uniformBufferChunkSize = 0;
 	};
 
 	struct VulkanPipeline
@@ -93,7 +95,7 @@ namespace Rbk {
 		void CopyBuffer(VkCommandPool commandPool, VkBuffer srcBuffer, VkBuffer dstBuffer, VkDeviceSize size);
 		bool SouldResizeSwapChain(VkSwapchainKHR swapChain);
 		std::pair<VkBuffer, VkDeviceMemory> CreateUniformBuffers(uint32_t uniformBuffersCount);
-		void UpdateUniformBuffer(std::pair<VkBuffer, VkDeviceMemory>uniformBuffer, UniformBufferObject uniformBufferObject);
+		void UpdateUniformBuffer(std::pair<VkBuffer, VkDeviceMemory>uniformBuffer, std::vector<UniformBufferObject> uniformBufferObjects, uint32_t uniformBuffersCount);
 		void CreateImage(uint32_t width, uint32_t height, uint32_t mipLevels, VkSampleCountFlagBits numSamples, VkFormat format, VkImageTiling tiling, VkImageUsageFlags usage, VkMemoryPropertyFlags properties, VkImage& image, VkDeviceMemory& imageMemory);
 		VkImageView CreateImageView(VkImage image, VkFormat format, uint32_t mipLevels, VkImageAspectFlags aspectFlags = VK_IMAGE_ASPECT_COLOR_BIT);
 		void CreateTextureImage(VkCommandBuffer commandBuffer, stbi_uc* pixels, int texWidth, int texHeight, uint32_t mipLevels, VkImage& textureImage, VkDeviceMemory& textureImageMemory, VkFormat format);

--- a/src/Rebulk/Renderer/Vulkan/VulkanRenderer.h
+++ b/src/Rebulk/Renderer/Vulkan/VulkanRenderer.h
@@ -78,6 +78,7 @@ namespace Rbk {
 		VkDescriptorPool CreateDescriptorPool(std::vector<VkImage> swapChainImages);
 		VkDescriptorSetLayout CreateDescriptorSetLayout(uint32_t meshCount);
 		VkDescriptorSet CreateDescriptorSets(VkDescriptorPool descriptorPool, std::vector<VkImage> swapChainImages, std::vector<VkDescriptorSetLayout> descriptorSetLayouts);
+		void UpdateDescriptorSets(VulkanMesh vMesh, std::map<const char*, VulkanTexture> vTextures, VulkanPipeline pipeline);
 		VkPipelineLayout CreatePipelineLayout(std::vector<VkDescriptorSet> descriptorSets, std::vector<VkDescriptorSetLayout> descriptorSetLayouts);
 		VkPipeline CreateGraphicsPipeline(VkRenderPass renderPass, VulkanPipeline pipeline, VulkanShaders shaders, bool wireFrameModeOn = false);
 		VkSwapchainKHR CreateSwapChain(std::vector<VkImage>& swapChainImages, VkSwapchainKHR oldSwapChain = VK_NULL_HANDLE);
@@ -114,7 +115,7 @@ namespace Rbk {
 		void SetViewPort(VkCommandBuffer commandBuffer);
 		void SetScissor(VkCommandBuffer commandBuffer);
 		void BindPipeline(VkCommandBuffer commandBuffer, VkPipeline pipeline);
-		void Draw(VkCommandBuffer commandBuffer, VulkanMesh vMesh, std::map<const char*, VulkanTexture>, VulkanPipeline pipeline);
+		void Draw(VkCommandBuffer commandBuffer, VulkanMesh vMesh, VulkanPipeline pipeline);
 		uint32_t AcquireNextImageKHR(VkSwapchainKHR swapChain, std::pair<std::vector<VkSemaphore>, std::vector<VkSemaphore>>& semaphores);
 		void QueueSubmit(VkCommandBuffer commandBuffer);
 		void QueueSubmit(uint32_t imageIndex, VkCommandBuffer commandBuffer, std::pair<std::vector<VkSemaphore>, std::vector<VkSemaphore>>& semaphores);

--- a/src/Rebulk/Renderer/Vulkan/VulkanRenderer.h
+++ b/src/Rebulk/Renderer/Vulkan/VulkanRenderer.h
@@ -31,12 +31,11 @@ namespace Rbk {
 	{
 		Rbk::Mesh mesh;
 		uint32_t vertexIndicesCount = 0;
-		std::vector<uint32_t>vertexOffset = {};
-		std::vector<uint32_t>indicesOffset = {};
 		std::pair<VkBuffer, VkDeviceMemory> meshVBuffer = { nullptr, nullptr };
 		std::pair<VkBuffer, VkDeviceMemory> meshIBuffer = { nullptr, nullptr };
 		std::vector<std::pair<VkBuffer, VkDeviceMemory>>uniformBuffers;
 		int32_t count = 0;
+		int32_t totalInstances = 0;
 		int32_t uniformBuffersCount = 0;
 		int32_t uniformBufferChunkSize = 0;
 	};

--- a/src/Rebulk/Renderer/Vulkan/VulkanRenderer.h
+++ b/src/Rebulk/Renderer/Vulkan/VulkanRenderer.h
@@ -80,7 +80,7 @@ namespace Rbk {
 		VkShaderModule CreateShaderModule(const std::vector<char>& code);
 		VkDescriptorPool CreateDescriptorPool(uint32_t size);
 		VkDescriptorSetLayout CreateDescriptorSetLayout();
-		VkDescriptorSet CreateDescriptorSets(VkDescriptorPool descriptorPool, std::vector<VkImage> swapChainImages, std::vector<VkDescriptorSetLayout> descriptorSetLayouts);
+		VkDescriptorSet CreateDescriptorSets(VkDescriptorPool descriptorPool, std::vector<VkDescriptorSetLayout> descriptorSetLayouts);
 		void UpdateDescriptorSets(VulkanMesh vMesh, std::pair<VkBuffer, VkDeviceMemory> uniformBuffer, std::map<const char*, VulkanTexture> vTextures, VkDescriptorSet descriptorSet);
 		VkPipelineLayout CreatePipelineLayout(std::vector<VkDescriptorSet> descriptorSets, std::vector<VkDescriptorSetLayout> descriptorSetLayouts);
 		VkPipeline CreateGraphicsPipeline(VkRenderPass renderPass, VulkanPipeline pipeline, VulkanShaders shaders, bool wireFrameModeOn = false);

--- a/src/Rebulk/Renderer/Vulkan/VulkanRenderer.h
+++ b/src/Rebulk/Renderer/Vulkan/VulkanRenderer.h
@@ -34,10 +34,12 @@ namespace Rbk {
 		std::pair<VkBuffer, VkDeviceMemory> meshVBuffer = { nullptr, nullptr };
 		std::pair<VkBuffer, VkDeviceMemory> meshIBuffer = { nullptr, nullptr };
 		std::vector<std::pair<VkBuffer, VkDeviceMemory>>uniformBuffers;
+		std::vector<int32_t>uniformUBOCount;
 		int32_t count = 0;
 		int32_t totalInstances = 0;
 		int32_t uniformBuffersCount = 0;
 		int32_t uniformBufferChunkSize = 0;
+		int32_t maxUniformBufferRange = 0;
 	};
 
 	struct VulkanPipeline


### PR DESCRIPTION
Now get a chunk of N mesh for a ubo of max size maxUniformBufferRange (65536).
Still need to load only 1 set of vertices and 1 set of indices per identical mesh.

![Capture d’écran 2022-02-17 234556](https://user-images.githubusercontent.com/37900220/154584509-76b3f5a1-9484-4f62-b672-966dc770529d.png)

Now load only one time a mesh for multiple instances. Much better perf than previously. From 9 FPS to 247 FPS...
![Capture d’écran 2022-02-18 121900](https://user-images.githubusercontent.com/37900220/154673159-db0c4814-b578-4e99-ac2d-798c589c8762.png)

Now drawing 400 cubes, with 2 chunks and multiple descriptor set.
![Capture d’écran 2022-02-18 224004](https://user-images.githubusercontent.com/37900220/154764858-94ec7d7b-ca3b-4e5e-a61d-88839e329e04.png)

10 000 cubes, terrible performances...
![Capture d’écran 2022-02-18 230502](https://user-images.githubusercontent.com/37900220/154767660-37e522a8-d570-4ff8-bc2a-18aa6e88b2b2.png)

.

